### PR TITLE
feat: resume PDF auto-generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,9 @@ pnpm-debug.log*
 # test artifacts
 test-results/
 
+# generated resume PDF
+public/resume.pdf
+
 # yarn legacy
 .yarn/
+.vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "portfolio-v5",
+  "name": "portfolio-v4",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "portfolio-v5",
+      "name": "portfolio-v4",
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.2",
@@ -15,6 +15,7 @@
         "@astrojs/tailwind": "^6.0.2",
         "@playwright/test": "^1.50.0",
         "tailwindcss": "^3.4.0",
+        "tsx": "^4.21.0",
         "vitest": "^3.1.0"
       }
     },
@@ -3045,6 +3046,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -5165,6 +5179,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -5795,6 +5819,41 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "4.41.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "tsx scripts/resume/generate.ts && astro build",
+    "resume:generate": "tsx scripts/resume/generate.ts",
+    "resume:preview": "tsx scripts/resume/preview.ts",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run",
@@ -18,6 +20,7 @@
     "@astrojs/tailwind": "^6.0.2",
     "@playwright/test": "^1.50.0",
     "tailwindcss": "^3.4.0",
+    "tsx": "^4.21.0",
     "vitest": "^3.1.0"
   }
 }

--- a/scripts/resume/generate.ts
+++ b/scripts/resume/generate.ts
@@ -1,0 +1,45 @@
+import { chromium } from "playwright";
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import { transform } from "./transform";
+import { renderTemplate } from "./template";
+
+const OUTPUT_PATH = join(process.cwd(), "public", "resume.pdf");
+const TEMP_HTML = join("/tmp", `resume-${Date.now()}.html`);
+
+async function generate(): Promise<void> {
+  const data = transform();
+  const html = renderTemplate(data);
+
+  writeFileSync(TEMP_HTML, html, "utf-8");
+
+  const publicDir = join(process.cwd(), "public");
+  if (!existsSync(publicDir)) {
+    mkdirSync(publicDir, { recursive: true });
+  }
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(`file://${TEMP_HTML}`, { waitUntil: "networkidle" });
+    await page.pdf({
+      path: OUTPUT_PATH,
+      format: "A4",
+      printBackground: true,
+      margin: { top: "0", right: "0", bottom: "0", left: "0" },
+    });
+    console.log(`Resume PDF generated at ${OUTPUT_PATH}`);
+  } finally {
+    await browser.close();
+    try {
+      unlinkSync(TEMP_HTML);
+    } catch {
+      // temp file cleanup is best-effort
+    }
+  }
+}
+
+generate().catch((error) => {
+  console.error("Failed to generate resume PDF:", error);
+  process.exit(1);
+});

--- a/scripts/resume/preview.ts
+++ b/scripts/resume/preview.ts
@@ -1,0 +1,17 @@
+import { writeFileSync } from "fs";
+import { exec } from "child_process";
+import { transform } from "./transform";
+import { renderTemplate } from "./template";
+
+const PREVIEW_PATH = "/tmp/resume-preview.html";
+
+const data = transform();
+const html = renderTemplate(data);
+writeFileSync(PREVIEW_PATH, html, "utf-8");
+
+console.log(`Preview written to ${PREVIEW_PATH}`);
+exec(`open ${PREVIEW_PATH}`, (error) => {
+  if (error) {
+    console.log(`Open it manually: file://${PREVIEW_PATH}`);
+  }
+});

--- a/scripts/resume/template.ts
+++ b/scripts/resume/template.ts
@@ -1,0 +1,483 @@
+import type { ResumeData } from "./transform";
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function renderTemplate(data: ResumeData): string {
+  const highlightsHtml = data.highlights
+    .map(
+      (h) => `
+        <div class="highlight-card">
+          <div class="highlight-metric">${escapeHtml(h.metric)}</div>
+          <div class="highlight-label">${escapeHtml(h.label)}</div>
+        </div>`
+    )
+    .join("\n");
+
+  const experienceHtml = data.experience
+    .map(
+      (exp) => `
+        <div class="exp-item">
+          <div class="exp-top">
+            <div class="exp-role">${escapeHtml(exp.title)}</div>
+            <div class="exp-dates">${escapeHtml(exp.dates)}</div>
+          </div>
+          <div class="exp-company">${escapeHtml(exp.company)}</div>
+          <ul class="exp-bullets">
+            ${exp.bullets.map((b) => `<li>${escapeHtml(b)}</li>`).join("\n            ")}
+          </ul>
+        </div>`
+    )
+    .join("\n");
+
+  const skillsHtml = data.skillGroups
+    .map(
+      (group) => `
+        <div class="sidebar-skill-group">
+          <div class="sidebar-skill-label">${escapeHtml(group.category)}</div>
+          <div class="sidebar-skill-items">
+            ${group.skills.map((s) => `<span class="sidebar-skill">${escapeHtml(s)}</span>`).join("")}
+          </div>
+        </div>`
+    )
+    .join("\n");
+
+  const productsHtml = data.products
+    .map(
+      (p) => `
+        <div class="product-card">
+          <div class="product-top">
+            <span class="product-name">${escapeHtml(p.name)}</span>
+            <span class="product-scope">${escapeHtml(p.scope)}</span>
+          </div>
+          <div class="product-desc">${escapeHtml(p.description)}</div>
+        </div>`
+    )
+    .join("\n");
+
+  const certsHtml = data.certifications
+    .map(
+      (cert) => `
+        <div class="cert-row">
+          <div class="cert-name">${escapeHtml(cert.name)}</div>
+          <div class="cert-detail">${escapeHtml(cert.org)} &middot; ${escapeHtml(cert.year)}</div>
+        </div>`
+    )
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>${escapeHtml(data.name)} — Resume</title>
+  <style>
+    @page {
+      size: A4;
+      margin: 0;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-size: 10px;
+      line-height: 1.5;
+      color: #2d2d2d;
+      background: #ffffff;
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    /* ─── Page Layout ─── */
+    .page {
+      width: 210mm;
+      height: 297mm;
+      display: flex;
+    }
+
+    /* ─── Sidebar ─── */
+    .sidebar {
+      width: 66mm;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      padding: 32px 16px 32px 20px;
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .sidebar a {
+      color: #c0c0c0;
+    }
+
+    .sidebar-name {
+      font-size: 24px;
+      font-weight: 700;
+      color: #ffffff;
+      line-height: 1.15;
+      margin-bottom: 4px;
+    }
+
+    .sidebar-title {
+      font-size: 10px;
+      font-weight: 600;
+      color: #FA5252;
+      letter-spacing: 0.3px;
+      margin-bottom: 28px;
+      line-height: 1.4;
+    }
+
+    .sidebar-section {
+      margin-bottom: 24px;
+    }
+
+    .sidebar-section:last-child {
+      margin-bottom: 0;
+    }
+
+    .sidebar-section-title {
+      font-size: 7.5px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 2.5px;
+      color: #FA5252;
+      margin-bottom: 12px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid rgba(250, 82, 82, 0.25);
+    }
+
+    /* Contact */
+    .contact-item {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      margin-bottom: 9px;
+      font-size: 8.5px;
+      line-height: 1.4;
+      color: #c0c0c0;
+    }
+
+    .contact-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      background: rgba(250, 82, 82, 0.12);
+      color: #FA5252;
+      border-radius: 4px;
+      font-size: 8px;
+      font-weight: 700;
+      flex-shrink: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+
+    /* Skills in sidebar */
+    .sidebar-skill-group {
+      margin-bottom: 14px;
+    }
+
+    .sidebar-skill-group:last-child {
+      margin-bottom: 0;
+    }
+
+    .sidebar-skill-label {
+      font-size: 8.5px;
+      font-weight: 600;
+      color: #ffffff;
+      margin-bottom: 6px;
+      letter-spacing: 0.2px;
+    }
+
+    .sidebar-skill-items {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+
+    .sidebar-skill {
+      display: inline-block;
+      font-size: 7.5px;
+      color: #d0d0d0;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 3px;
+      padding: 3px 7px;
+      line-height: 1.3;
+    }
+
+    /* Certifications in sidebar */
+    .cert-row {
+      margin-bottom: 10px;
+    }
+
+    .cert-row:last-child {
+      margin-bottom: 0;
+    }
+
+    .cert-name {
+      font-size: 8px;
+      color: #e0e0e0;
+      line-height: 1.4;
+      font-weight: 500;
+    }
+
+    .cert-detail {
+      font-size: 7px;
+      color: #777;
+      margin-top: 2px;
+    }
+
+    /* ─── Main Content ─── */
+    .main {
+      flex: 1;
+      padding: 32px 28px 32px 26px;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .main-section-title {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      color: #1a1a2e;
+      margin-bottom: 12px;
+      padding-bottom: 6px;
+      border-bottom: 2px solid #FA5252;
+    }
+
+    /* Highlights */
+    .highlights-section {
+      margin-bottom: 22px;
+    }
+
+    .highlights-grid {
+      display: flex;
+      gap: 10px;
+    }
+
+    .highlight-card {
+      flex: 1;
+      text-align: center;
+      padding: 12px 6px 10px;
+      background: #f8f8fa;
+      border-radius: 6px;
+      border: 1px solid #eeeef0;
+    }
+
+    .highlight-metric {
+      font-size: 20px;
+      font-weight: 800;
+      color: #FA5252;
+      line-height: 1.1;
+      margin-bottom: 3px;
+    }
+
+    .highlight-label {
+      font-size: 6.5px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #999;
+    }
+
+    /* Summary */
+    .summary-section {
+      margin-bottom: 22px;
+    }
+
+    .summary-text {
+      font-size: 10px;
+      color: #444;
+      line-height: 1.7;
+    }
+
+    /* Experience */
+    .experience-section {
+      flex: 1;
+    }
+
+    .exp-item {
+      margin-bottom: 22px;
+    }
+
+    .exp-item:last-child {
+      margin-bottom: 0;
+    }
+
+    .exp-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 2px;
+    }
+
+    .exp-role {
+      font-size: 12px;
+      font-weight: 700;
+      color: #1a1a2e;
+    }
+
+    .exp-company {
+      font-size: 10px;
+      color: #FA5252;
+      font-weight: 500;
+      margin-bottom: 8px;
+    }
+
+    .exp-dates {
+      font-size: 9px;
+      color: #999;
+      white-space: nowrap;
+      font-weight: 500;
+    }
+
+    .exp-bullets {
+      padding-left: 16px;
+    }
+
+    .exp-bullets li {
+      font-size: 9.5px;
+      color: #444;
+      line-height: 1.7;
+      margin-bottom: 5px;
+    }
+
+    .exp-bullets li:last-child {
+      margin-bottom: 0;
+    }
+
+    .exp-bullets li::marker {
+      color: #FA5252;
+      font-size: 8px;
+    }
+
+    /* Products */
+    .products-section {
+      margin-top: 22px;
+    }
+
+    .products-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .product-card {
+      padding: 10px 14px;
+      background: #f8f8fa;
+      border-radius: 6px;
+      border-left: 3px solid #FA5252;
+    }
+
+    .product-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 3px;
+    }
+
+    .product-name {
+      font-size: 10px;
+      font-weight: 700;
+      color: #1a1a2e;
+    }
+
+    .product-scope {
+      font-size: 8px;
+      color: #999;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .product-desc {
+      font-size: 9px;
+      color: #555;
+      line-height: 1.55;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <aside class="sidebar">
+      <div class="sidebar-name">${escapeHtml(data.name)}</div>
+      <div class="sidebar-title">${escapeHtml(data.title)}</div>
+
+      <div class="sidebar-section">
+        <div class="sidebar-section-title">Contact</div>
+        <div class="contact-item">
+          <span class="contact-icon">E</span>
+          <a href="mailto:${escapeHtml(data.contact.email)}">${escapeHtml(data.contact.email)}</a>
+        </div>
+        <div class="contact-item">
+          <span class="contact-icon">P</span>
+          <span>${escapeHtml(data.contact.phone)}</span>
+        </div>
+        <div class="contact-item">
+          <span class="contact-icon">L</span>
+          <span>${escapeHtml(data.contact.location)}</span>
+        </div>
+        ${data.links
+          .map(
+            (link) =>
+              `<div class="contact-item"><span class="contact-icon">${link.label === "LinkedIn" ? "in" : link.label === "GitHub" ? "G" : "W"}</span><a href="${escapeHtml(link.url)}">${escapeHtml(link.url.replace("https://www.", "").replace("https://", ""))}</a></div>`
+          )
+          .join("\n        ")}
+      </div>
+
+      <div class="sidebar-section">
+        <div class="sidebar-section-title">Skills</div>
+        ${skillsHtml}
+      </div>
+
+      <div class="sidebar-section">
+        <div class="sidebar-section-title">Certifications</div>
+        ${certsHtml}
+      </div>
+    </aside>
+
+    <main class="main">
+      <section class="highlights-section">
+        <div class="main-section-title">Highlights</div>
+        <div class="highlights-grid">
+          ${highlightsHtml}
+        </div>
+      </section>
+
+      <section class="summary-section">
+        <div class="main-section-title">Summary</div>
+        <p class="summary-text">${escapeHtml(data.summary)}</p>
+      </section>
+
+      <section class="experience-section">
+        <div class="main-section-title">Experience</div>
+        ${experienceHtml}
+      </section>
+
+      <section class="products-section">
+        <div class="main-section-title">Products I Own</div>
+        <div class="products-grid">
+          ${productsHtml}
+        </div>
+      </section>
+    </main>
+  </div>
+</body>
+</html>`;
+}

--- a/scripts/resume/transform.ts
+++ b/scripts/resume/transform.ts
@@ -1,0 +1,168 @@
+import { personal } from "../../src/data/personal";
+import { experiences } from "../../src/data/experiences";
+import { skillGroups } from "../../src/data/skills";
+import { certifications } from "../../src/data/certifications";
+
+export interface ResumeLink {
+  readonly label: string;
+  readonly url: string;
+}
+
+export interface ResumeHighlight {
+  readonly metric: string;
+  readonly label: string;
+}
+
+export interface ResumeExperience {
+  readonly title: string;
+  readonly company: string;
+  readonly dates: string;
+  readonly bullets: readonly string[];
+}
+
+export interface ResumeSkillGroup {
+  readonly category: string;
+  readonly skills: readonly string[];
+}
+
+export interface ResumeCertification {
+  readonly name: string;
+  readonly org: string;
+  readonly year: string;
+}
+
+export interface ResumeProduct {
+  readonly name: string;
+  readonly description: string;
+  readonly scope: string;
+}
+
+export interface ResumeData {
+  readonly name: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly contact: {
+    readonly email: string;
+    readonly phone: string;
+    readonly location: string;
+  };
+  readonly links: readonly ResumeLink[];
+  readonly highlights: readonly ResumeHighlight[];
+  readonly experience: readonly ResumeExperience[];
+  readonly products: readonly ResumeProduct[];
+  readonly skillGroups: readonly ResumeSkillGroup[];
+  readonly certifications: readonly ResumeCertification[];
+}
+
+function extractYear(dateStr: string): string {
+  const match = dateStr.match(/\d{4}/);
+  return match ? match[0] : dateStr;
+}
+
+function sortPrimariesFirst(
+  skills: readonly { title: string; primary?: boolean }[]
+): string[] {
+  const primaries = skills.filter((s) => s.primary).map((s) => s.title);
+  const others = skills.filter((s) => !s.primary).map((s) => s.title);
+  return [...primaries, ...others];
+}
+
+/**
+ * Resume-specific experience bullets, rewritten for PM impact framing.
+ * The website data (experiences.ts) uses general descriptions.
+ * The resume needs: action verb + scope + scale + outcome.
+ */
+const RESUME_BULLETS: Record<string, readonly string[]> = {
+  "Ringkas (PT Ringkas Asia Technology)": [
+    "Own end-to-end loan origination platform serving multiple banking partners across Southeast Asian markets",
+    "Drive product strategy for AI-powered document processing and conversational AI platform, reducing manual lending operations",
+    "Built and manage central configuration hub governing feature flags and rollout controls across all products and markets",
+    "Author PRDs, define API contracts, and align cross-border architecture decisions between Vietnam and Indonesia engineering teams",
+    "Transitioned from Software Engineer to Product Manager through demonstrated product ownership and cross-functional leadership",
+  ],
+  "Bizzi Vietnam": [
+    "Led development of AI-powered invoice extraction pipeline, reducing manual data entry for enterprise clients including Mega Market, Circle K, and The Coffee House",
+    "Designed and shipped PO email processing service end-to-end, from database schema to production deployment",
+    "Delivered Oracle and SAP enterprise integrations, enabling automated data exchange across 3 major retail chains",
+  ],
+};
+
+const RESUME_SUMMARY =
+  "Software Engineer turned Product Manager with 5+ years in fintech and AI. " +
+  "Own three platform products at Ringkas spanning loan origination, AI document processing, " +
+  "and configuration management, coordinating engineering teams across Vietnam and Indonesia.";
+
+const PRODUCTS: readonly ResumeProduct[] = [
+  {
+    name: "LOS Core",
+    description:
+      "Loan origination platform powering end-to-end mortgage workflows for multiple banking partners across Southeast Asian markets",
+    scope: "Multi-market",
+  },
+  {
+    name: "RISA",
+    description:
+      "AI-powered platform combining document processing, data extraction, and conversational AI to automate lending operations",
+    scope: "AI / ML",
+  },
+  {
+    name: "Tarvos",
+    description:
+      "Central configuration hub managing feature flags, system configs, and rollout controls across all products and markets",
+    scope: "Cross-platform",
+  },
+];
+
+const HIGHLIGHTS: readonly ResumeHighlight[] = [
+  { metric: "3", label: "Products Owned" },
+  { metric: "SE→PM", label: "Career Growth" },
+  { metric: "2", label: "Markets" },
+  { metric: "5+", label: "Years Experience" },
+];
+
+export function transform(): ResumeData {
+  const experience: ResumeExperience[] = experiences.map((exp) => ({
+    title: exp.jobTitle,
+    company: exp.companyName,
+    dates: `${exp.startDate} — ${exp.endDate ?? "Present"}`,
+    bullets: RESUME_BULLETS[exp.companyName] ?? exp.description,
+  }));
+
+  const resumeSkillGroups: ResumeSkillGroup[] = skillGroups.map((group) => ({
+    category: group.category,
+    skills: sortPrimariesFirst(group.skills),
+  }));
+
+  const sortedCerts = [...certifications].sort((a, b) => {
+    const yearA = parseInt(extractYear(a.date), 10);
+    const yearB = parseInt(extractYear(b.date), 10);
+    return yearB - yearA;
+  });
+
+  const resumeCerts: ResumeCertification[] = sortedCerts.map((cert) => ({
+    name: cert.name,
+    org: cert.organization,
+    year: extractYear(cert.date),
+  }));
+
+  const links: ResumeLink[] = personal.socials
+    .filter((s) => s.title === "LinkedIn" || s.title === "GitHub")
+    .map((s) => ({ label: s.title, url: s.url }));
+
+  return {
+    name: personal.fullName,
+    title: personal.title,
+    summary: RESUME_SUMMARY,
+    contact: {
+      email: personal.contact.email,
+      phone: personal.contact.phone,
+      location: personal.contact.location,
+    },
+    links,
+    highlights: HIGHLIGHTS,
+    experience,
+    products: PRODUCTS,
+    skillGroups: resumeSkillGroups,
+    certifications: resumeCerts,
+  };
+}

--- a/src/data/personal.ts
+++ b/src/data/personal.ts
@@ -35,5 +35,5 @@ export const personal: Personal = {
     { title: "Telegram", url: "https://t.me/phamanhduy", icon: "telegram" },
     { title: "Zalo", url: "https://zalo.me/0963769049", icon: "zalo" },
   ],
-  resumeUrl: "",
+  resumeUrl: "/resume.pdf",
 };


### PR DESCRIPTION
## Summary

Auto-generate a resume PDF from the portfolio's existing TypeScript data files. The "Download Resume" button on duypham.me now works.

**Pipeline:** `src/data/*.ts` → `transform.ts` → `template.ts` → Playwright → `public/resume.pdf`

- **Infrastructure:** Added `tsx` devDependency, `resume:generate` and `resume:preview` npm scripts, build command auto-regenerates PDF
- **Resume scripts:** `scripts/resume/` with transform (data reshaping + PM-focused bullets), template (two-column dark sidebar layout), generate (Playwright PDF), preview (browser helper)
- **Download button:** `resumeUrl` in `personal.ts` set to `/resume.pdf`

### Design highlights
- Two-column layout: dark sidebar (contact, skills, certs) + white main (highlights, summary, experience, products)
- Highlights cards: 3 Products Owned, SE→PM Career Growth, 2 Markets, 5+ Years
- PM-focused content framing with achievement-oriented bullets
- "Products I Own" section with LOS Core, RISA, Tarvos cards
- ATS-parseable: real text, system fonts, clean hierarchy

## Test Coverage
- All 19 existing unit tests pass
- Build pipeline verified: `tsx scripts/resume/generate.ts && astro build` succeeds
- PDF output: 1-page A4, 383KB, valid PDF

## Test plan
- [x] `npm run resume:generate` produces valid PDF at `public/resume.pdf`
- [x] `npm run build` auto-regenerates resume then builds Astro
- [x] All 19 unit tests pass
- [x] PDF is 1 page, ATS-parseable (real text, selectable)
- [ ] Verify download button works on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)