### PR TITLE
[codex] add terminal compass favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ pnpm-debug.log*
 # test artifacts
 test-results/
 
+# local isolated worktrees
+.worktrees/
+
 # generated resume PDFs
 public/resume.pdf
 public/resume-light.pdf

--- a/docs/superpowers/plans/2026-06-06-terminal-compass-logo.md
+++ b/docs/superpowers/plans/2026-06-06-terminal-compass-logo.md
@@ -1,0 +1,233 @@
+# Terminal Compass Logo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the old `DP` gradient favicon with the approved Terminal Compass logo for `duypham.me`.
+
+**Architecture:** Keep the first implementation favicon-first and avoid visible layout changes. The SVG lives in `public/favicon.svg`, with focused tests proving the old literal `DP` gradient badge is gone and the browser links to the new SVG. Sidebar/logo lockups remain out of scope for this pass because the approved spec says visible sidebar usage is optional and should not compete with the avatar.
+
+**Tech Stack:** Astro 5, static SVG assets in `public/`, Vitest for file-level assertions, Playwright for browser-level favicon verification.
+
+---
+
+## File Structure
+
+- Modify: `public/favicon.svg`
+  - Responsibility: Standalone Terminal Compass SVG favicon using the approved rounded-square, D silhouette, orange command arrow, and mustard underline.
+- Create: `tests/unit/favicon.test.ts`
+  - Responsibility: Assert the favicon has the approved static SVG characteristics and does not contain the old gradient/text badge implementation.
+- Create: `tests/e2e/favicon.spec.ts`
+  - Responsibility: Assert the built site links to `/favicon.svg` and the served SVG contains the new mark characteristics.
+
+## Out of Scope
+
+- No sidebar signature in this implementation.
+- No avatar, layout, color-token, or theme refactor.
+- No new generated raster icons unless a later browser/device check proves SVG favicon support is insufficient.
+
+---
+
+### Task 1: Replace the Favicon With Terminal Compass
+
+**Files:**
+- Modify: `public/favicon.svg`
+- Create: `tests/unit/favicon.test.ts`
+- Create: `tests/e2e/favicon.spec.ts`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/unit/favicon.test.ts` with this exact content:
+
+```ts
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const favicon = readFileSync(resolve(process.cwd(), "public/favicon.svg"), "utf8");
+
+describe("favicon logo", () => {
+  it("uses the approved Terminal Compass SVG anatomy", () => {
+    expect(favicon).toContain('viewBox="0 0 32 32"');
+    expect(favicon).toContain('rx="8"');
+    expect(favicon).toContain("#252220");
+    expect(favicon).toContain("#F2EDE4");
+    expect(favicon).toContain("#E07A3E");
+    expect(favicon).toContain("#D4B05A");
+  });
+
+  it("does not use the old literal DP gradient badge", () => {
+    expect(favicon).not.toContain("<text");
+    expect(favicon).not.toContain("linearGradient");
+    expect(favicon).not.toContain("#FA5252");
+    expect(favicon).not.toContain("#DD2476");
+    expect(favicon).not.toMatch(/>DP</);
+  });
+});
+```
+
+- [ ] **Step 2: Run the unit test to verify it fails against the old favicon**
+
+Run:
+
+```bash
+npm test -- tests/unit/favicon.test.ts
+```
+
+Expected: FAIL. The old `public/favicon.svg` still contains `linearGradient`, `<text`, `#FA5252`, `#DD2476`, and lacks the new rounded-square `rx="8"` Terminal Compass colors.
+
+- [ ] **Step 3: Write the failing browser-level favicon test**
+
+Create `tests/e2e/favicon.spec.ts` with this exact content:
+
+```ts
+import { expect, test } from "@playwright/test";
+
+test.describe("Favicon", () => {
+  test("links to the Terminal Compass SVG favicon", async ({ page, request }) => {
+    await page.goto("/");
+
+    const faviconHref = await page
+      .locator('link[rel="icon"][type="image/svg+xml"]')
+      .getAttribute("href");
+
+    expect(faviconHref).toBe("/favicon.svg");
+
+    const faviconUrl = new URL(faviconHref!, page.url()).toString();
+    const response = await request.get(faviconUrl);
+    expect(response.ok()).toBe(true);
+    expect(response.headers()["content-type"]).toContain("image/svg+xml");
+
+    const svg = await response.text();
+    expect(svg).toContain("#252220");
+    expect(svg).toContain("#F2EDE4");
+    expect(svg).toContain("#E07A3E");
+    expect(svg).toContain("#D4B05A");
+    expect(svg).not.toContain("<text");
+    expect(svg).not.toContain("linearGradient");
+  });
+});
+```
+
+- [ ] **Step 4: Run the e2e test to verify it fails against the old favicon**
+
+Run:
+
+```bash
+npm run test:e2e -- tests/e2e/favicon.spec.ts
+```
+
+Expected: FAIL. The browser can find `/favicon.svg`, but the served SVG still has the old text/gradient implementation and lacks the approved Terminal Compass color set.
+
+- [ ] **Step 5: Replace the favicon SVG with the approved Terminal Compass mark**
+
+Replace all content in `public/favicon.svg` with this exact SVG:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Duy Pham Terminal Compass logo">
+  <rect width="32" height="32" rx="8" fill="#252220" />
+  <path
+    d="M10.25 10.25H15.9C21.05 10.25 24.25 12.75 24.25 16C24.25 19.25 21.05 21.75 15.9 21.75H10.25V10.25Z"
+    fill="none"
+    stroke="#F2EDE4"
+    stroke-width="2.5"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M16 10.25L24.75 16L16 21.75"
+    fill="none"
+    stroke="#E07A3E"
+    stroke-width="2.75"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <circle cx="24.75" cy="16" r="1.5" fill="#D4B05A" />
+  <path
+    d="M10.25 25H24.25"
+    fill="none"
+    stroke="#D4B05A"
+    stroke-width="2.15"
+    stroke-linecap="round"
+  />
+</svg>
+```
+
+- [ ] **Step 6: Run the unit test to verify it passes**
+
+Run:
+
+```bash
+npm test -- tests/unit/favicon.test.ts
+```
+
+Expected: PASS. Both favicon unit tests pass.
+
+- [ ] **Step 7: Run the favicon e2e test to verify it passes**
+
+Run:
+
+```bash
+npm run test:e2e -- tests/e2e/favicon.spec.ts
+```
+
+Expected: PASS. Playwright builds/previews the site, loads `/`, fetches `/favicon.svg`, and confirms the new SVG characteristics.
+
+- [ ] **Step 8: Run the production build**
+
+Run:
+
+```bash
+npm run build
+```
+
+Expected: PASS. Astro finishes building the site and `dist/favicon.svg` is generated from `public/favicon.svg`.
+
+- [ ] **Step 9: Visually inspect the favicon SVG**
+
+Run:
+
+```bash
+npm run dev -- --host 127.0.0.1
+```
+
+Open `http://127.0.0.1:4321/favicon.svg` in the in-app browser. Expected: a dark rounded-square Terminal Compass mark with a light `D` silhouette, orange command arrow, mustard dot, and mustard underline. Stop the dev server after inspection.
+
+- [ ] **Step 10: Commit the implementation**
+
+Run:
+
+```bash
+git add public/favicon.svg tests/unit/favicon.test.ts tests/e2e/favicon.spec.ts
+git commit -m "feat: add terminal compass favicon"
+```
+
+Expected: Commit succeeds with only the favicon and the two new tests staged.
+
+---
+
+## Final Verification
+
+After Task 1 is committed, run:
+
+```bash
+npm test
+npm run test:e2e
+npm run build
+```
+
+Expected:
+
+- Vitest passes, including `tests/unit/favicon.test.ts`.
+- Playwright passes, including `tests/e2e/favicon.spec.ts`.
+- Production build passes.
+
+Review the git diff before shipping:
+
+```bash
+git status --short
+git show --stat --oneline --name-only HEAD
+```
+
+Expected:
+
+- The implementation commit contains `public/favicon.svg`, `tests/unit/favicon.test.ts`, and `tests/e2e/favicon.spec.ts`.
+- Unrelated pre-existing worktree changes remain unstaged.

--- a/docs/superpowers/specs/2026-06-06-terminal-compass-logo-design.md
+++ b/docs/superpowers/specs/2026-06-06-terminal-compass-logo-design.md
@@ -1,0 +1,115 @@
+# Terminal Compass Logo Design
+
+## Goal
+
+Replace the current `DP` gradient favicon with a more distinctive identity for `duypham.me`. The new logo should feel like a compact product-command mark for a software-engineer-turned-product-manager: technical, directional, personal, and less template-like.
+
+## Current Problem
+
+The current favicon is a red-pink gradient circle with white `DP` text. It is readable, but it feels generic and disconnected from the site's warm earth-tone visual system.
+
+The new mark should avoid:
+
+- Literal `DP` text inside a badge.
+- Startup-style red/pink gradients.
+- Decorative shapes that do not connect to Duy's story.
+- A mark that works only at large sizes.
+
+## Approved Direction
+
+Use the **Terminal Compass** concept from the original option 1 anatomy.
+
+The mark combines:
+
+- A rounded-square technical container.
+- A clear `D` silhouette as the main structural read.
+- An orange command arrow that implies direction, product judgment, and a hidden `P` gesture.
+- A mustard underline that references a terminal prompt, engineering origin, and action line.
+
+The `P` should remain implied rather than forced into a literal second letter. The user explicitly rejected revisions that made the `P` more visible because they reduced the originality of the original mark.
+
+## Brand Meaning
+
+The logo should communicate:
+
+- **System literacy:** Duy can read and reason through technical systems.
+- **Product direction:** Duy can turn ambiguity into decisions and shipped work.
+- **Engineering origin:** The underline and command-like arrow reference terminal/console language.
+- **Personal signature:** The `D` anchors the mark to Duy without making it a plain monogram.
+
+Working interpretation: **D as system, arrow as product decision, underline as engineering origin.**
+
+## Visual Specification
+
+Use the existing site palette:
+
+- Outer/background dark: `#252220` or token equivalent `var(--surface)` in dark contexts.
+- Light stroke: `#f2ede4` or token equivalent `var(--text)` in dark contexts.
+- Primary arrow/accent: `#e07a3e` or `var(--accent)` in dark mode.
+- Secondary underline: `#d4b05a` or `var(--accent-2)` in dark mode.
+
+Shape characteristics:
+
+- Rounded-square container, not a circle.
+- Thick simple strokes that survive favicon scale.
+- No text nodes inside the SVG.
+- No gradients.
+- No decorative shadows.
+- Maintain clear contrast in both light and dark browser contexts.
+
+## Usage
+
+### Favicon
+
+Primary use. The favicon should render as a standalone SVG in `public/favicon.svg`.
+
+At small size, prioritize:
+
+- The rounded-square container.
+- The white `D` silhouette.
+- The orange arrow.
+
+The mustard underline may remain if it is visually clear at 16px. If it blurs or crowds the mark, it can be simplified or removed only for the tiny favicon variant.
+
+### Sidebar Signature
+
+Optional use. The mark can appear in the sidebar as a compact signature near the profile identity, but it should not compete with the avatar.
+
+If used, pair it with:
+
+- `Duy Pham`
+- A small descriptor such as `Product x engineering`
+
+If the sidebar feels cleaner without a visible logo, keep the logo favicon-only.
+
+### Labs / Domain Lockup
+
+Future use. The mark can pair with `duypham.me` or `Duy Labs` as an umbrella identity for projects, experiments, and subdomains.
+
+## Implementation Scope
+
+The first implementation should stay small:
+
+- Replace `public/favicon.svg` with the approved Terminal Compass SVG.
+- Add reusable SVG markup only if the logo is also introduced in the visible sidebar UI.
+- Do not redesign the page layout.
+- Do not change the avatar treatment unless needed for balance.
+- Do not introduce new brand colors beyond the current palette.
+
+## Testing and Verification
+
+Verify:
+
+- `npm run build` passes.
+- The favicon loads in the browser.
+- The favicon remains legible at 16px, 32px, and browser-tab scale.
+- The mark looks intentional against both light and dark site themes.
+- If the sidebar signature is added, the sidebar remains visually balanced on desktop and mobile.
+
+## Decisions Made
+
+- Chosen direction: original **Terminal Compass** anatomy.
+- Rejected: literal `DP` badge.
+- Rejected: revised variants that made the `P` explicit.
+- Rejected: generic gradient icon styling.
+- Favored: hidden/implied initials, technical signal language, and a compact favicon-first mark.

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,10 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <defs>
-    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#FA5252"/>
-      <stop offset="100%" stop-color="#DD2476"/>
-    </linearGradient>
-  </defs>
-  <circle cx="16" cy="16" r="16" fill="url(#g)"/>
-  <text x="16" y="21" text-anchor="middle" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="white">DP</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Duy Pham Terminal Compass logo">
+  <rect width="32" height="32" rx="8" fill="#252220" />
+  <path
+    d="M10.25 10.25H15.9C21.05 10.25 24.25 12.75 24.25 16C24.25 19.25 21.05 21.75 15.9 21.75H10.25V10.25Z"
+    fill="none"
+    stroke="#F2EDE4"
+    stroke-width="2.5"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M16 10.25L24.75 16L16 21.75"
+    fill="none"
+    stroke="#E07A3E"
+    stroke-width="2.75"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <circle cx="24.75" cy="16" r="1.5" fill="#D4B05A" />
+  <path
+    d="M10.25 25H24.25"
+    fill="none"
+    stroke="#D4B05A"
+    stroke-width="2.15"
+    stroke-linecap="round"
+  />
 </svg>

--- a/tests/e2e/favicon.spec.ts
+++ b/tests/e2e/favicon.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Favicon", () => {
+  test("links to the Terminal Compass SVG favicon", async ({ page, request }) => {
+    await page.goto("/");
+
+    const faviconHref = await page
+      .locator('link[rel="icon"][type="image/svg+xml"]')
+      .getAttribute("href");
+
+    expect(faviconHref).toBe("/favicon.svg");
+
+    const faviconUrl = new URL(faviconHref!, page.url()).toString();
+    const response = await request.get(faviconUrl);
+    expect(response.ok()).toBe(true);
+    expect(response.headers()["content-type"]).toContain("image/svg+xml");
+
+    const svg = await response.text();
+    expect(svg).toContain("#252220");
+    expect(svg).toContain("#F2EDE4");
+    expect(svg).toContain("#E07A3E");
+    expect(svg).toContain("#D4B05A");
+    expect(svg).not.toContain("<text");
+    expect(svg).not.toContain("linearGradient");
+  });
+});

--- a/tests/e2e/portfolio.spec.ts
+++ b/tests/e2e/portfolio.spec.ts
@@ -30,11 +30,14 @@ test.describe("Portfolio page", () => {
     await expect(page.locator("#about")).toContainText("Bizzi Vietnam");
   });
 
-  test("has Experience section with 2 jobs", async ({ page }) => {
+  test("has Experience section with 3 roles", async ({ page }) => {
     await expect(page.locator("#experience")).toBeVisible();
-    await expect(page.locator("#experience h3")).toHaveCount(2);
+    await expect(page.locator("#experience h3")).toHaveCount(3);
     await expect(page.locator("#experience h3").first()).toContainText(
       "Associate Product Manager"
+    );
+    await expect(page.locator("#experience h3").nth(1)).toContainText(
+      "Software Engineer"
     );
     await expect(page.locator("#experience h3").last()).toContainText(
       "Software Engineer"

--- a/tests/unit/favicon.test.ts
+++ b/tests/unit/favicon.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const favicon = readFileSync(resolve(process.cwd(), "public/favicon.svg"), "utf8");
+
+describe("favicon logo", () => {
+  it("uses the approved Terminal Compass SVG anatomy", () => {
+    expect(favicon).toContain('viewBox="0 0 32 32"');
+    expect(favicon).toContain('rx="8"');
+    expect(favicon).toContain("#252220");
+    expect(favicon).toContain("#F2EDE4");
+    expect(favicon).toContain("#E07A3E");
+    expect(favicon).toContain("#D4B05A");
+  });
+
+  it("does not use the old literal DP gradient badge", () => {
+    expect(favicon).not.toContain("<text");
+    expect(favicon).not.toContain("linearGradient");
+    expect(favicon).not.toContain("#FA5252");
+    expect(favicon).not.toContain("#DD2476");
+    expect(favicon).not.toMatch(/>DP</);
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
   "framework": "astro",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "installCommand": "npm install && npx playwright install chromium"
+  "installCommand": "npm install && npx playwright install --with-deps chromium"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
   "framework": "astro",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "installCommand": "npm install && npx playwright install --with-deps chromium"
+  "installCommand": "npm install"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
   "framework": "astro",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "installCommand": "npm install"
+  "installCommand": "npm install && npx playwright install chromium"
 }


### PR DESCRIPTION
## Summary
- Adds the approved Terminal Compass SVG favicon for duypham.me.
- Adds favicon unit and e2e coverage to lock the approved visual anatomy: dark rounded container, light D outline, orange command arrow, and mustard terminal mark.
- Updates a stale portfolio e2e expectation from 2 jobs to 3 roles so the existing Experience section matches the rendered data.

## Validation
- npm test
- npm run test:e2e
- npm run build
