### PR TITLE
[codex] add labs page

### DIFF
--- a/src/components/LabCard.astro
+++ b/src/components/LabCard.astro
@@ -1,0 +1,233 @@
+---
+import type { LabProject } from "../data/labs";
+
+interface Props {
+  project: LabProject;
+}
+
+const { project } = Astro.props;
+const host = project.liveUrl ? new URL(project.liveUrl).host.replace(/^www\./, "") : "Live pending";
+const updated = new Intl.DateTimeFormat("en", {
+  month: "short",
+  year: "numeric",
+}).format(new Date(`${project.updatedAt}T00:00:00Z`));
+
+const statusTone = {
+  Live: "status-live",
+  Building: "status-building",
+  Paused: "status-paused",
+  Archived: "status-archived",
+}[project.status];
+---
+
+<article class="lab-card" style={`--lab-accent: ${project.accent}`}>
+  <div class="flex items-start gap-4">
+    <div class="lab-mark" aria-hidden="true">
+      <span>{project.name.slice(0, 2)}</span>
+    </div>
+    <div class="min-w-0 flex-1">
+      <p class="text-[11px] uppercase tracking-[1.8px] text-muted font-semibold mb-1">
+        {project.type}
+      </p>
+      <h3 class="text-xl font-bold text-text leading-tight">{project.name}</h3>
+    </div>
+  </div>
+
+  <p class="text-sm text-muted leading-[1.75] mt-4 min-h-[74px]">
+    {project.description}
+  </p>
+
+  <div class="flex flex-wrap gap-2 mt-4" aria-label={`${project.name} tags`}>
+    {project.tags.map((tag) => <span class="lab-tag">{tag}</span>)}
+  </div>
+
+  <div class="flex items-center justify-between gap-3 mt-5 pt-5 border-t border-border">
+    <div class="min-w-0">
+      <div class={`lab-status ${statusTone}`}>{project.status}</div>
+      <p class="text-[12px] text-muted mt-1 truncate">{host} · {updated}</p>
+    </div>
+
+    <div class="flex items-center gap-2 shrink-0">
+      {
+        project.liveUrl ? (
+          <a
+            href={project.liveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="lab-action lab-action-primary"
+            aria-label={`Open live project ${project.name}`}
+            title={`Open ${project.name}`}
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M7 17 17 7" />
+              <path d="M9 7h8v8" />
+            </svg>
+            <span>Live</span>
+          </a>
+        ) : (
+          <span class="lab-action lab-action-disabled" aria-label={`${project.name} live URL pending`}>
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 8v4l2.5 2.5" />
+              <path d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            </svg>
+            <span>Soon</span>
+          </span>
+        )
+      }
+
+      <a
+        href={project.githubUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="lab-action"
+        aria-label={`Open GitHub repository for ${project.name}`}
+        title={`${project.name} on GitHub`}
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M15 22v-4a4.8 4.8 0 0 0-1.3-3.7c4.3-.5 8.8-2.1 8.8-9.4A7.4 7.4 0 0 0 20.5 0 6.8 6.8 0 0 1 20.3 4S18.7 3.5 15 6A18.4 18.4 0 0 0 9 6C5.3 3.5 3.7 4 3.7 4A6.8 6.8 0 0 1 3.5 0a7.4 7.4 0 0 0-2 4.9c0 7.3 4.5 8.9 8.8 9.4A4.8 4.8 0 0 0 9 18v4" />
+          <path d="M9 19c-4.5 1.5-5-2-7-2" />
+        </svg>
+        <span>GitHub</span>
+      </a>
+    </div>
+  </div>
+</article>
+
+<style>
+  .lab-card {
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--lab-accent) 10%, transparent), transparent 42%),
+      var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.4rem;
+    min-height: 316px;
+    transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+  }
+
+  .lab-card:hover {
+    border-color: color-mix(in srgb, var(--lab-accent) 55%, var(--border));
+    transform: translateY(-2px);
+    box-shadow: 0 14px 34px color-mix(in srgb, var(--lab-accent) 14%, transparent);
+  }
+
+  .lab-mark {
+    width: 52px;
+    height: 52px;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    color: var(--bg);
+    background:
+      radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.42), transparent 28%),
+      var(--lab-accent);
+    box-shadow: inset 0 -10px 24px rgba(0, 0, 0, 0.14);
+    flex: 0 0 auto;
+  }
+
+  .lab-mark span {
+    font-size: 0.86rem;
+    line-height: 1;
+    font-weight: 800;
+  }
+
+  .lab-tag {
+    border: 1px solid color-mix(in srgb, var(--lab-accent) 36%, var(--border));
+    background: color-mix(in srgb, var(--lab-accent) 12%, var(--surface));
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.65rem;
+    font-size: 0.72rem;
+    line-height: 1;
+    font-weight: 600;
+  }
+
+  .lab-status {
+    width: fit-content;
+    border-radius: 999px;
+    padding: 0.28rem 0.58rem;
+    font-size: 0.68rem;
+    line-height: 1;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .status-live {
+    background: rgba(47, 158, 143, 0.16);
+    color: #2f9e8f;
+  }
+
+  .status-building {
+    background: rgba(184, 146, 58, 0.18);
+    color: var(--accent-2-text);
+  }
+
+  .status-paused {
+    background: rgba(111, 103, 216, 0.16);
+    color: #756ee0;
+  }
+
+  .status-archived {
+    background: rgba(139, 115, 85, 0.16);
+    color: var(--muted);
+  }
+
+  .lab-action {
+    min-height: 36px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--surface-hover);
+    color: var(--text);
+    padding: 0.52rem 0.68rem;
+    font-size: 0.76rem;
+    line-height: 1;
+    font-weight: 750;
+    transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease;
+  }
+
+  .lab-action:hover {
+    border-color: var(--lab-accent);
+    color: var(--lab-accent);
+  }
+
+  .lab-action-primary {
+    background: var(--lab-accent);
+    border-color: var(--lab-accent);
+    color: var(--bg);
+  }
+
+  .lab-action-primary:hover {
+    background: color-mix(in srgb, var(--lab-accent) 84%, var(--text));
+    color: var(--bg);
+  }
+
+  .lab-action-disabled {
+    opacity: 0.62;
+    cursor: default;
+  }
+
+  .lab-action svg {
+    width: 15px;
+    height: 15px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  @media (max-width: 480px) {
+    .lab-card {
+      min-height: auto;
+      padding: 1.2rem;
+    }
+
+    .lab-action span {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -6,6 +6,11 @@ import { socialIcons } from "../data/icons";
 import ThemeToggle from "./ThemeToggle.astro";
 
 const { fullName, title, contact, socials, resumeUrls } = personal;
+const pathname = Astro.url.pathname;
+const navLinks = [
+  { href: "/", label: "Portfolio", active: pathname === "/" },
+  { href: "/labs", label: "Labs", active: pathname.startsWith("/labs") },
+];
 ---
 
 <aside class="relative lg:sticky lg:top-6 h-fit">
@@ -35,6 +40,23 @@ const { fullName, title, contact, socials, resumeUrls } = personal;
 
     <!-- Divider -->
     <div class="h-px bg-border my-5"></div>
+
+    <nav class="grid grid-cols-2 gap-2 mb-5" aria-label="Site navigation">
+      {navLinks.map((link) => (
+        <a
+          href={link.href}
+          class:list={[
+            "rounded-[12px] border px-3 py-2.5 text-[12px] font-semibold transition-colors",
+            link.active
+              ? "bg-accent text-bg border-accent"
+              : "bg-surface-hover text-muted border-border hover:border-accent hover:text-accent",
+          ]}
+          aria-current={link.active ? "page" : undefined}
+        >
+          {link.label}
+        </a>
+      ))}
+    </nav>
 
     <!-- Contact info -->
     <div class="text-left space-y-3">

--- a/src/data/labs.ts
+++ b/src/data/labs.ts
@@ -1,0 +1,96 @@
+export type LabStatus = "Live" | "Building" | "Paused" | "Archived";
+
+export interface LabProject {
+  readonly name: string;
+  readonly slug: string;
+  readonly description: string;
+  readonly status: LabStatus;
+  readonly type: string;
+  readonly tags: readonly string[];
+  readonly liveUrl?: string;
+  readonly githubUrl: string;
+  readonly updatedAt: string;
+  readonly accent: string;
+}
+
+export const labs: readonly LabProject[] = [
+  {
+    name: "EVoyage",
+    slug: "evoyage",
+    description:
+      "Plan EV road trips with range calculations, charger-aware stops, and a route flow tuned for Vietnamese travel.",
+    status: "Live",
+    type: "Travel tool",
+    tags: ["EV", "Maps", "Next.js"],
+    liveUrl: "https://evoyage.duypham.me/",
+    githubUrl: "https://github.com/duypham9895/evoyage",
+    updatedAt: "2026-06-06",
+    accent: "#2f9e8f",
+  },
+  {
+    name: "PM Assessment Gym",
+    slug: "pm-assessment-gym",
+    description:
+      "Practice analytical product-management cases with mock prompts, answer structure, and focused scoring rubrics.",
+    status: "Live",
+    type: "Product practice",
+    tags: ["PM", "Analytics", "React"],
+    liveUrl: "https://pmbench.duypham.me",
+    githubUrl: "https://github.com/duypham9895/pm-assessment-gym",
+    updatedAt: "2026-06-06",
+    accent: "#b8541f",
+  },
+  {
+    name: "Easel",
+    slug: "easel",
+    description:
+      "A couples wellbeing app concept that turns cycle tracking into phase-aware guidance and timely support signals.",
+    status: "Live",
+    type: "AI companion",
+    tags: ["AI", "Wellbeing", "TypeScript"],
+    liveUrl: "https://duypham9895.github.io/easel/",
+    githubUrl: "https://github.com/duypham9895/easel",
+    updatedAt: "2026-03-23",
+    accent: "#c9567c",
+  },
+  {
+    name: "Split Bill",
+    slug: "split-bill",
+    description:
+      "A no-backend trip expense splitter for Vietnamese groups, with VND-first flows, VietQR support, and bilingual UI.",
+    status: "Building",
+    type: "Finance utility",
+    tags: ["Finance", "VietQR", "TypeScript"],
+    githubUrl: "https://github.com/duypham9895/split-bill",
+    updatedAt: "2026-06-01",
+    accent: "#b8923a",
+  },
+  {
+    name: "Foray",
+    slug: "foray",
+    description:
+      "A campaign room for job hunting: capture applications, ingest recruiter emails, classify movement, and decide the next action.",
+    status: "Building",
+    type: "Job search tool",
+    tags: ["Careers", "Gmail", "TypeScript"],
+    githubUrl: "https://github.com/duypham9895/foray",
+    updatedAt: "2026-05-12",
+    accent: "#6f67d8",
+  },
+  {
+    name: "Đà Lạt Random Picker",
+    slug: "dalat-random-picker",
+    description:
+      "A lightweight picker for food and travel ideas in Đà Lạt, with categories, local storage, and mobile-friendly interactions.",
+    status: "Live",
+    type: "Local travel tool",
+    tags: ["Travel", "Vietnam", "JavaScript"],
+    liveUrl: "https://duypham9895.github.io/dalat-random-picker/",
+    githubUrl: "https://github.com/duypham9895/dalat-random-picker",
+    updatedAt: "2025-10-27",
+    accent: "#4c9f70",
+  },
+];
+
+export const liveLabs = labs.filter((lab) => lab.status === "Live");
+export const buildingLabs = labs.filter((lab) => lab.status === "Building");

--- a/src/pages/labs.astro
+++ b/src/pages/labs.astro
@@ -1,0 +1,182 @@
+---
+import Layout from "../layouts/Layout.astro";
+import LabCard from "../components/LabCard.astro";
+import Footer from "../components/Footer.astro";
+import { buildingLabs, labs, liveLabs } from "../data/labs";
+
+const githubCount = labs.filter((lab) => lab.githubUrl).length;
+const statuses = ["All", "Live", "Building"] as const;
+---
+
+<Layout
+  title="Duy Labs — Side Projects by Duy Pham"
+  description="A living catalog of Duy Pham's side projects, experiments, live products, and GitHub repositories under duypham.me and beyond."
+>
+  <section class="md:col-span-2 card fade-in labs-hero" aria-labelledby="labs-title">
+    <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+      <div class="max-w-[680px]">
+        <p class="section-label">Labs</p>
+        <h2 id="labs-title" class="text-[2.55rem] md:text-[3.35rem] leading-[0.98] font-bold text-text">
+          Duy Labs
+        </h2>
+        <p class="text-base md:text-lg text-muted leading-[1.75] mt-5">
+          A map of side projects, experiments, tools, and small product ideas I am building around
+          <span class="text-text font-semibold">duypham.me</span>.
+        </p>
+      </div>
+
+      <div class="labs-stats" aria-label="Labs summary">
+        <div>
+          <strong>{labs.length}</strong>
+          <span>projects</span>
+        </div>
+        <div>
+          <strong>{liveLabs.length}</strong>
+          <span>live</span>
+        </div>
+        <div>
+          <strong>{githubCount}</strong>
+          <span>repos</span>
+        </div>
+      </div>
+    </div>
+
+    <nav class="labs-status-nav" aria-label="Labs status shortcuts">
+      {statuses.map((status) => (
+        <a href={status === "All" ? "#labs-grid" : `#${status.toLowerCase()}`}>
+          {status}
+        </a>
+      ))}
+      <a href="https://github.com/duypham9895" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </nav>
+  </section>
+
+  <section class="md:col-span-2" aria-labelledby="live">
+    <div class="labs-section-head">
+      <div>
+        <h2 id="live" class="text-2xl font-bold text-text">Live and active</h2>
+        <p class="text-sm text-muted mt-2 leading-relaxed">
+          Public projects with live URLs, repositories, current status, and a quick read on what each one does.
+        </p>
+      </div>
+      <span>{liveLabs.length} online</span>
+    </div>
+
+    <div id="labs-grid" class="grid grid-cols-1 xl:grid-cols-2 gap-4 mt-4">
+      {liveLabs.map((project) => <LabCard project={project} />)}
+      {buildingLabs.map((project) => <LabCard project={project} />)}
+    </div>
+  </section>
+
+  <section id="building" class="md:col-span-2 card labs-note" aria-label="Labs note">
+    <div>
+      <h2 class="text-xl font-bold text-text">Always in motion</h2>
+      <p class="text-sm text-muted leading-[1.8] mt-3">
+        Some projects are stable, some are prototypes, and a few are still becoming useful. The page stays focused on
+        what is live, what is being built, and where the code lives.
+      </p>
+    </div>
+  </section>
+
+  <div class="md:col-span-2">
+    <Footer />
+  </div>
+</Layout>
+
+<style>
+  .labs-hero {
+    overflow: hidden;
+    position: relative;
+  }
+
+  .labs-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.6rem;
+    min-width: min(100%, 320px);
+  }
+
+  .labs-stats div {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--bg) 44%, transparent);
+    padding: 0.95rem;
+  }
+
+  .labs-stats strong {
+    display: block;
+    color: var(--text);
+    font-size: 1.55rem;
+    line-height: 1;
+  }
+
+  .labs-stats span {
+    display: block;
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+    margin-top: 0.42rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .labs-status-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-top: 1.6rem;
+  }
+
+  .labs-status-nav a {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    color: var(--text);
+    background: var(--surface-hover);
+    padding: 0.58rem 0.9rem;
+    font-size: 0.78rem;
+    font-weight: 750;
+    transition: border-color 150ms ease, color 150ms ease;
+  }
+
+  .labs-status-nav a:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .labs-section-head {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .labs-section-head span {
+    border: 1px solid rgba(47, 158, 143, 0.32);
+    border-radius: 999px;
+    color: #2f9e8f;
+    background: rgba(47, 158, 143, 0.12);
+    padding: 0.45rem 0.7rem;
+    font-size: 0.72rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    white-space: nowrap;
+  }
+
+  .labs-note {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  @media (max-width: 640px) {
+    .labs-stats {
+      grid-template-columns: 1fr;
+    }
+
+    .labs-section-head {
+      align-items: start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/tests/e2e/labs.spec.ts
+++ b/tests/e2e/labs.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Labs page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/labs");
+  });
+
+  test("renders the labs catalog", async ({ page }) => {
+    await expect(page).toHaveTitle(/Labs/);
+    await expect(page.locator("h2", { hasText: "Duy Labs" })).toBeVisible();
+    await expect(page.locator("#labs-grid article")).toHaveCount(6);
+  });
+
+  test("shows project metadata and clear actions", async ({ page }) => {
+    await expect(page.locator("#labs-grid")).toContainText("Live");
+    await expect(page.locator("#labs-grid")).toContainText("GitHub");
+    await expect(page.locator("#labs-grid")).toContainText("AI");
+    await expect(page.locator('a[aria-label^="Open live project"]')).toHaveCount(4);
+    await expect(page.locator('a[aria-label^="Open GitHub repository"]')).toHaveCount(6);
+  });
+
+  test("links back to the main portfolio", async ({ page }) => {
+    const homeLink = page.locator('a[href="/"]', { hasText: "Portfolio" });
+    await expect(homeLink).toBeVisible();
+  });
+});
+
+test.describe("Labs responsive layout", () => {
+  test("mobile renders readable project cards", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/labs");
+    await expect(page.locator("h2", { hasText: "Duy Labs" })).toBeVisible();
+    await expect(page.locator("#labs-grid article").first()).toBeVisible();
+    await expect(page.locator('a[aria-label^="Open live project"]').first()).toBeVisible();
+  });
+});

--- a/tests/unit/data.test.ts
+++ b/tests/unit/data.test.ts
@@ -3,6 +3,7 @@ import { personal } from "../../src/data/personal";
 import { experiences } from "../../src/data/experiences";
 import { skillGroups } from "../../src/data/skills";
 import { certifications } from "../../src/data/certifications";
+import { labs } from "../../src/data/labs";
 
 describe("personal data", () => {
   it("has correct name", () => {
@@ -135,6 +136,30 @@ describe("certifications data", () => {
   it("no Basic-level certs remain", () => {
     certifications.forEach((cert) => {
       expect(cert.name).not.toMatch(/\(Basic\)/);
+    });
+  });
+});
+
+describe("labs data", () => {
+  it("has a useful starter catalog", () => {
+    expect(labs.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("has unique slugs", () => {
+    const slugs = labs.map((lab) => lab.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("has at least one live project", () => {
+    expect(labs.some((lab) => lab.status === "Live")).toBe(true);
+  });
+
+  it("uses valid project links when provided", () => {
+    labs.forEach((lab) => {
+      if (lab.liveUrl) expect(lab.liveUrl).toMatch(/^https:\/\//);
+      if (lab.githubUrl) expect(lab.githubUrl).toMatch(/^https:\/\//);
+      expect(lab.tags.length).toBeGreaterThan(0);
+      expect(lab.description.length).toBeGreaterThan(20);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `/labs` as a public catalog of side projects with live links, GitHub links, status, tags, and quick project metadata.
- Adds a reusable `LabCard` component and typed `src/data/labs.ts` catalog.
- Adds sidebar navigation so Labs is discoverable from the portfolio shell.
- Adds unit and Playwright coverage for the Labs data contract and route.

## Root cause
The Labs feature existed only as local untracked/draft files, so it was never included in the previous logo PR or production deployment.

## Validation
- `npm test`
- `npm run test:e2e`
- `npm run build`
- Desktop and mobile screenshot inspection of `/labs`
