### PR TITLE
[codex] sync local repo docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ pnpm-debug.log*
 # test artifacts
 test-results/
 
+# local agent scratch artifacts
+.superpowers/
+
 # local isolated worktrees
 .worktrees/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+## Skill routing
+
+When the user's request matches an available skill, ALWAYS invoke it using the Skill
+tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
+The skill has specialized workflows that produce better results than ad-hoc answers.
+
+Key routing rules:
+
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken", 500 errors → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review

--- a/docs/superpowers/plans/2026-06-06-labs-page.md
+++ b/docs/superpowers/plans/2026-06-06-labs-page.md
@@ -1,0 +1,51 @@
+# Labs Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `duypham.me/labs` as a useful catalog of Duy's side projects with live links, GitHub links, statuses, and tags.
+
+**Architecture:** Keep the page in the existing Astro portfolio app. Store project entries in a typed data module, render each entry through a reusable Astro card, expose `/labs` through `src/pages/labs.astro`, and add a small navigation link from the existing sidebar.
+
+**Tech Stack:** Astro 5, Tailwind CSS tokens already defined in `src/styles/global.css`, Vitest, Playwright.
+
+---
+
+### Task 1: Data Contract And Page Tests
+
+**Files:**
+- Modify: `tests/unit/data.test.ts`
+- Create: `tests/e2e/labs.spec.ts`
+
+- [ ] Add unit tests that import `labs`, assert at least four entries, require unique slugs, require absolute `https://` live/GitHub links when present, and require at least one live project.
+- [ ] Add Playwright tests that visit `/labs`, assert the page title/heading, visible project cards, `Live` and `GitHub` actions, and mobile rendering.
+- [ ] Run `npm test` and `npx playwright test tests/e2e/labs.spec.ts`; both should fail until the implementation files exist.
+
+### Task 2: Labs Data And Card Component
+
+**Files:**
+- Create: `src/data/labs.ts`
+- Create: `src/components/LabCard.astro`
+
+- [ ] Define `LabProject` with `name`, `slug`, `description`, `status`, `type`, `tags`, `liveUrl`, `githubUrl`, `updatedAt`, and `accent`.
+- [ ] Seed the first version with editable project entries that clearly demonstrate live links, GitHub links, active/building/paused statuses, and tags.
+- [ ] Build `LabCard.astro` with separate `Live` and `GitHub` actions, non-ambiguous labels, status metadata, and tag chips.
+
+### Task 3: Labs Route And Navigation
+
+**Files:**
+- Create: `src/pages/labs.astro`
+- Modify: `src/components/Sidebar.astro`
+
+- [ ] Render the route with the existing `Layout`, page intro, quick stats, filter-like status links, grouped project cards, and a footer.
+- [ ] Add `Labs` navigation to the sidebar without disrupting the existing resume and social actions.
+- [ ] Keep the visual system aligned with the current warm earth palette and dark/light theme.
+
+### Task 4: Verification
+
+**Files:**
+- No source files unless fixes are needed.
+
+- [ ] Run `npm test`.
+- [ ] Run `npm run build`.
+- [ ] Run `npx playwright test tests/e2e/labs.spec.ts`.
+- [ ] Start the dev server, capture desktop and mobile screenshots of `/labs`, inspect them visually, and fix any layout or readability issues.


### PR DESCRIPTION
## Summary
- Adds the repo-local `AGENTS.md` instruction file that was present only in the local checkout.
- Adds the Labs page implementation plan under `docs/superpowers/plans`.
- Ignores `.superpowers/` local brainstorming artifacts so generated scratch files do not keep appearing as untracked work.

## Notes
- Excludes `.superpowers/` generated scratch files.
- Excludes the stale local `src/pages/labs.astro` draft because production already has the polished `/labs` version from PR #6.

## Validation
- `npm test`
- `npm run build`
- `npm run test:e2e`
