### PR TITLE
Fix duplicate Vercel Git CI failures

### DIFF
--- a/scripts/vercel/ignore-git-build.mjs
+++ b/scripts/vercel/ignore-git-build.mjs
@@ -1,0 +1,11 @@
+const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+
+if (isGitHubActions) {
+  console.log("Continuing GitHub Actions build for prebuilt Vercel deployment.");
+  process.exit(1);
+}
+
+console.log(
+  "Skipping Vercel Git build. GitHub Actions deploys prebuilt output with Playwright dependencies."
+);
+process.exit(0);

--- a/tests/unit/vercel-ignore.test.ts
+++ b/tests/unit/vercel-ignore.test.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = resolve("scripts/vercel/ignore-git-build.mjs");
+
+function runIgnoreScript(extraEnv: Record<string, string | undefined> = {}) {
+  const env = { ...process.env };
+
+  for (const [key, value] of Object.entries(extraEnv)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+
+  return spawnSync(process.execPath, [scriptPath], {
+    cwd: process.cwd(),
+    encoding: "utf-8",
+    env,
+  });
+}
+
+describe("Vercel Git build gate", () => {
+  it("skips automatic Vercel Git builds", () => {
+    const result = runIgnoreScript({ GITHUB_ACTIONS: undefined });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Skipping Vercel Git build");
+  });
+
+  it("allows the GitHub Actions prebuilt deployment pipeline to build", () => {
+    const result = runIgnoreScript({ GITHUB_ACTIONS: "true" });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("Continuing GitHub Actions build");
+  });
+
+  it("wires the gate into Vercel configuration", () => {
+    const vercelConfig = JSON.parse(readFileSync("vercel.json", "utf-8"));
+
+    expect(vercelConfig.ignoreCommand).toBe("node scripts/vercel/ignore-git-build.mjs");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "framework": "astro",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "ignoreCommand": "node scripts/vercel/ignore-git-build.mjs"
 }


### PR DESCRIPTION
## Root cause

Vercel's Git integration was running its own build on every pushed branch/commit. That direct Vercel build runs `npm run build`, which generates resume PDFs through Playwright. The Git builder does not have Playwright Chromium installed, and installing only Chromium still fails because Vercel's build image is missing browser system libraries such as `libnspr4.so`. The `--with-deps` variant also fails because the Git builder has no `apt-get`.

The actual production deploy pipeline is the GitHub Actions workflow. It installs Playwright Chromium with system dependencies, runs the build, then deploys prebuilt output to Vercel. Those runs have been green.

## Fix

Add an explicit Vercel ignored-build gate so automatic Vercel Git builds are skipped, while GitHub Actions builds continue. This removes the duplicate failing pipeline and keeps the real production deploy path intact.

## Verification

- `npm test -- tests/unit/vercel-ignore.test.ts` fails before the gate exists, then passes after implementation
- `npm test`: 30 passed
- `npm run build`: passed and generated both resume PDFs
- `npm run test:e2e`: 18 passed
- `GITHUB_ACTIONS=true vercel build --prod`: completed successfully before cleanup, confirming the ignore gate does not block the prebuilt deploy path